### PR TITLE
表示範囲の選択機能

### DIFF
--- a/docs/assets/js/draw-chart.js
+++ b/docs/assets/js/draw-chart.js
@@ -14,6 +14,10 @@ function renderChartContainerTemplate(content, chartIndexEntry, chartNumber) {
 
 
 function trimChartData(forPastDays, chartDataOrigin) {
+    if (forPastDays == 99999) {
+        return chartDataOrigin;
+    }
+
     var chartDataTrimed = [];
     dateTrimed = new Date();
     dateTrimed.setDate(dateTrimed.getDate() - forPastDays);

--- a/docs/assets/js/draw-chart.js
+++ b/docs/assets/js/draw-chart.js
@@ -13,6 +13,33 @@ function renderChartContainerTemplate(content, chartIndexEntry, chartNumber) {
 }
 
 
+function trimChartData(forPastDays, chartDataOrigin) {
+    var chartDataTrimed = [];
+    dateTrimed = new Date();
+    dateTrimed.setDate(dateTrimed.getDate() - forPastDays);
+
+    for (entryOrigin of chartDataOrigin) {
+        entryTrimed = {
+            series : entryOrigin.series,
+            points : []
+        };
+
+        var yBase = -1;
+        for (pointOrigin of entryOrigin["points"]) {
+            dateOrigin = new Date(pointOrigin.x);
+            if (dateOrigin > dateTrimed) {
+                if (yBase == -1) yBase = pointOrigin.y;
+                pointOrigin.y = pointOrigin.y - yBase;
+                entryTrimed.points.push(pointOrigin);
+            }
+        }
+        chartDataTrimed.push(entryTrimed);
+    }
+
+    return chartDataTrimed;
+}
+
+
 function attachChart(context, chartData) {
     var datasets = [];
     for (entry of chartData) {
@@ -56,6 +83,9 @@ function attachChart(context, chartData) {
 
 
 document.addEventListener('DOMContentLoaded', () => {
+    const saveState = sessionStorage.getItem('forThePastDates');
+    const forThePastDates = saveState ? parseInt(saveState, 10) : 99999;
+
     const parentNode = document.querySelector('#chart-plain');
     const templateContent = document.querySelector('#chart-container-template').content;
 
@@ -69,10 +99,35 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 fetch(chartIndex[i].data_file)
                     .then(response => response.json())
+                    .then(chartDataOrigin => trimChartData(forThePastDates, chartDataOrigin))
                     .then(chartData => {        
                         const context = document.getElementById("chart-canvas-" + i);
                         attachChart(context, chartData)
                     });
             }
         });
+});
+
+var forThePast030Dates = document.getElementById('forThePast030Dates');
+forThePast030Dates.addEventListener('click', () => {
+    sessionStorage.setItem('forThePastDates', '30');
+    location.reload();
+});
+
+var forThePast060Dates = document.getElementById('forThePast060Dates');
+forThePast060Dates.addEventListener('click', () => {
+    sessionStorage.setItem('forThePastDates', '60');
+    location.reload();
+});
+
+var forThePast180Dates = document.getElementById('forThePast180Dates');
+forThePast180Dates.addEventListener('click', () => {
+    sessionStorage.setItem('forThePastDates', '180');
+    location.reload();
+});
+
+var forThePastAllDates = document.getElementById('forThePastAllDates');
+forThePastAllDates.addEventListener('click', () => {
+    sessionStorage.removeItem('forThePastDates');
+    location.reload();
 });

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,16 @@
 
 <body>
   <div class="exastics-title"> Exastro Suite Statistics</div>
+
+  <table>
+    <tr>
+      <td><input type="button" value="For the past 30 dates" id="forThePast030Dates"></td>
+      <td><input type="button" value="For the past 60 dates" id="forThePast060Dates"></td>
+      <td><input type="button" value="For the past 180 dates" id="forThePast180Dates"></td>
+      <td><input type="button" value="For the past all dates" id="forThePastAllDates"></td>
+    </tr>
+  </table>
+
   <div id="chart-plain">
     <template id="chart-container-template">
       <div id="chart-container" class="exastics-chart-container">


### PR DESCRIPTION
表示範囲の選択を実現するため、以下２機能を試作。
(1) 画面上のボタン押下により、「過去ｘ日間」を表示範囲とする測定日でトリミング
(2) 「過去ｘ日間」の増加を求めるため、「ｘ日前」を０とするようカウントを減算

補足：
・(2) の機能が不要な場合、trimChartData内のyBaseを含む３行を削除することで排除可能。
・(1) の選択をブラウザ終了後も維持したい場合、sessionStorage→localStorageで可能なはず。

制限：
・(2)の処理により、「公開初日」のダウンロード数はカウント減算の対象となってしまう。
　「トリミング期間内に公開初日が来るものはカウント減算の対象としない」必要あり。
　ただ初日カウントは「０」または「テスト」と思われるため、ひとまずこのままとする。